### PR TITLE
Fix omado ascii art

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1175,21 +1175,22 @@ impl eframe::App for TodoApp {
                         // ASCII art on the left
                         ui.with_layout(egui::Layout::left_to_right(egui::Align::BOTTOM), |ui| {
                             let ascii_art = vec![
-                                "  ██████  ███    ███  █████  ██████   ██████ ",
-                                " ██    ██ ████  ████ ██   ██ ██   ██ ██    ██",
-                                " ██    ██ ██ ████ ██ ███████ ██   ██ ██    ██",
-                                " ██    ██ ██  ██  ██ ██   ██ ██   ██ ██    ██",
-                                "  ██████  ██      ██ ██   ██ ██████   ██████ ",
+                                "  ▄██████▄    ▄▄▄▄███▄▄▄▄      ▄████████ ████████▄   ▄██████▄ ",
+                                " ███    ███ ▄██▀▀▀███▀▀▀██▄   ███    ███ ███   ▀███ ███    ███",
+                                " ███    ███ ███   ███   ███   ███    ███ ███    ███ ███    ███",
+                                " ███    ███ ███   ███   ███   ███    ███ ███    ███ ███    ███",
+                                " ███    ███ ███   ███   ███ ▀███████████ ███    ███ ███    ███",
+                                " ███    ███ ███   ███   ███   ███    ███ ███    ███ ███    ███",
+                                " ███    ███ ███   ███   ███   ███    ███ ███   ▄███ ███    ███",
+                                "  ▀██████▀   ▀█   ███   █▀    ███    █▀  ████████▀   ▀██████▀ ",
                             ];
-                            
-                            ui.vertical(|ui| {
-                                for line in ascii_art {
-                                    ui.label(egui::RichText::new(line)
-                                        .color(self.theme.accent)
-                                        .size(8.0)
-                                        .monospace());
-                                }
-                            });
+                            let ascii_block = ascii_art.join("\n");
+                            ui.add(
+                                egui::Label::new(
+                                    egui::RichText::new(ascii_block)
+                                        .font(egui::FontId::monospace(8.0))
+                                ).wrap()
+                            );
                         });
                         
                         // Filter info on the right, bottom-aligned

--- a/src/main.rs
+++ b/src/main.rs
@@ -1188,7 +1188,9 @@ impl eframe::App for TodoApp {
                             ui.add(
                                 egui::Label::new(
                                     egui::RichText::new(ascii_block)
-                                        .font(egui::FontId::monospace(8.0))
+                                        .size(8.0)
+                                        .monospace()
+                                        .color(self.theme.accent)
                                 ).wrap()
                             );
                         });


### PR DESCRIPTION
1. Fixed the omado logo to match omarchy style
2. Fixed the line spacing between the logo characters

before: 
<img width="967" height="528" alt="before" src="https://github.com/user-attachments/assets/6015ddc0-abd6-42fa-a52c-f4f2ad693a6f" />
after:
<img width="964" height="528" alt="after" src="https://github.com/user-attachments/assets/2741127b-c37a-4307-be7e-065ce5531747" />

